### PR TITLE
Dev zhaoy 0809

### DIFF
--- a/lib/pages/chat/widgets/info_item.dart
+++ b/lib/pages/chat/widgets/info_item.dart
@@ -10,7 +10,6 @@ import 'package:flutter_link_previewer/flutter_link_previewer.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_sound/flutter_sound.dart';
 import 'package:get/get.dart';
-import 'package:logging/logging.dart';
 import 'package:orginone/dart/base/model.dart';
 import 'package:orginone/dart/base/schema.dart';
 import 'package:orginone/dart/controller/user_controller.dart';
@@ -113,9 +112,9 @@ class DetailItemWidget extends GetView<UserController> {
         child = Text.rich(TextSpan(children: [
           WidgetSpan(
               child: TargetText(
-                  style: XFonts.size18Black9,
-                  userId: msg.metadata.fromId,
-                  shareIcon: shareIcon,
+                style: XFonts.size18Black9,
+                userId: msg.metadata.fromId,
+                shareIcon: shareIcon,
               ),
               alignment: PlaceholderAlignment.middle),
           TextSpan(text: "撤回了一条消息", style: XFonts.size18Black9),

--- a/lib/pages/chat/widgets/info_item.dart
+++ b/lib/pages/chat/widgets/info_item.dart
@@ -3,12 +3,14 @@ import 'dart:convert';
 import 'dart:math';
 
 import 'package:custom_pop_up_menu/custom_pop_up_menu.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_link_previewer/flutter_link_previewer.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_sound/flutter_sound.dart';
 import 'package:get/get.dart';
+import 'package:logging/logging.dart';
 import 'package:orginone/dart/base/model.dart';
 import 'package:orginone/dart/base/schema.dart';
 import 'package:orginone/dart/controller/user_controller.dart';
@@ -92,14 +94,28 @@ class DetailItemWidget extends GetView<UserController> {
     if (msg.msgType == MessageType.recall.label) {
       Widget child;
       if (isSelf) {
-        child = Text("您撤回了一条消息", style: XFonts.size18Black9);
+        List<InlineSpan> recallMsgs=[TextSpan(text: "您撤回了一条消息", style: XFonts.size18Black9)];
+        
+        String msgStr=jsonDecode(msg.msgBody.substring(5))['body'];
+        if(!StringUtil.isJson(msgStr)) {
+          recallMsgs.add(TextSpan(text:" 重新编辑",style: TextStyle(color: Colors.blueAccent,fontSize: 20.sp),
+            recognizer: TapGestureRecognizer()
+            ..onTap = () {
+              ChatBoxController controller = Get.find<ChatBoxController>();
+
+              controller.inputController.text = msgStr;
+              controller.eventFire(context, InputEvent.clickInput, chat);
+            }
+          ));
+        }
+        child = Text.rich(TextSpan(children: recallMsgs));
       } else {
         child = Text.rich(TextSpan(children: [
           WidgetSpan(
               child: TargetText(
-                style: XFonts.size18Black9,
-                userId: msg.metadata.fromId,
-                shareIcon: shareIcon,
+                  style: XFonts.size18Black9,
+                  userId: msg.metadata.fromId,
+                  shareIcon: shareIcon,
               ),
               alignment: PlaceholderAlignment.middle),
           TextSpan(text: "撤回了一条消息", style: XFonts.size18Black9),

--- a/lib/util/string_util.dart
+++ b/lib/util/string_util.dart
@@ -127,4 +127,15 @@ class StringUtil {
   static String formatFileSize(int size) {
     return "${(size * 1.0 / 1024 / 1024).toStringAsFixed(1)}M";
   }
+
+  /// 判断文本是否为json字符串
+  static bool isJson(String str) {
+    bool isJsonStr=false;
+
+    try{
+      jsonDecode(str);
+      isJsonStr=true;
+    }catch(e){}
+    return isJsonStr;
+  }
 }


### PR DESCRIPTION
完成文档中的需求：沟通里面消息提交后撤回，没有编辑功能

支持范围：
目前该功能手机端仅支持文本类型的信息撤回重写，其他类型的信息暂时不支持撤回重写，对齐微信的方式，也是因为手机端的操作模式的原因。

暂时还存在的问题：
文本消息如果发送的是json数据，目前移动端也撤回不了。主要原因是撤回类型的消息本身没有存储被撤回信息的数据类型，因此目前只是通过被撤回消息是否为json字符串进行判断，进而导致无法撤回。也是因为这个原因，pc端撤回图片类型消息时，重写图片类型消息显示的是一窜json字符串，而不是被解析后的图片。
https://kdocs.cn/l/cs15lH5dKUB4