### PR TITLE
fix：1.部分安卓手机型号，在申请存储相关权限版本兼容问题 2.分享和保存的图片美化

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -56,7 +56,11 @@ android {
         // You can update the following values to match your application needs. 
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
         minSdkVersion 24
-        targetSdkVersion flutter.targetSdkVersion
+        //部分安卓手机型号，在申请存储相关权限时，无法获取存储权限，跳转到设置里，也无法找到存储相关
+        //发现是安卓13版本的问题安卓文档permission_handler的issues里面也有人提出了问题目前(2023-3-6) https://github.com/Baseflow/flutter-permission-handler/issues/995
+        //只能通过降低targetSdkVersion的办法解决，将targetSdkVersion从33变为32
+        // targetSdkVersion flutter.targetSdkVersion
+        targetSdkVersion 32
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,8 +4,10 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+    <!-- 读写权限 -->
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.VIBRATE" />

--- a/lib/pages/other/qr_scan/view.dart
+++ b/lib/pages/other/qr_scan/view.dart
@@ -6,7 +6,7 @@ import 'logic.dart';
 import 'state.dart';
 
 class QrScanPage extends BaseGetView<QrScanController, QrScanState> {
-  const QrScanPage({super.key});
+  QrScanPage();
 
   @override
   Widget buildView() {

--- a/lib/pages/other/share_qr_code/logic.dart
+++ b/lib/pages/other/share_qr_code/logic.dart
@@ -1,32 +1,27 @@
 import 'dart:io';
-
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 import 'package:image_gallery_saver/image_gallery_saver.dart';
-import 'package:orginone/config/constant.dart';
 import 'package:orginone/dart/base/model.dart';
 import 'package:orginone/dart/controller/user_controller.dart';
 import 'package:orginone/dart/core/enum.dart';
 import 'package:orginone/dart/core/getx/base_controller.dart';
 import 'package:orginone/main.dart';
-
 import 'package:orginone/pages/chat/message_forward.dart';
-import 'package:orginone/util/logger.dart';
 import 'package:orginone/util/toast_utils.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'dart:ui' as ui;
-
 import 'state.dart';
 
 class ShareQrCodeController extends BaseController<ShareQrCodeState> {
   final ShareQrCodeState state = ShareQrCodeState();
   final GlobalKey globalKey = GlobalKey();
   scan() {
-    Log.info('扫描');
+    // Log.info('扫描');
     UserController c = Get.find<UserController>();
     c.qrScan();
   }
@@ -54,7 +49,7 @@ class ShareQrCodeController extends BaseController<ShareQrCodeState> {
             builder: (context) {
               return MessageForward(
                 msgBody: MsgBodyModel.fromJson(item.shareInfo().toJson()),
-                msgType: MessageType.file.label,
+                msgType: MessageType.image.label,
                 onSuccess: () {
                   Navigator.pop(context);
                 },
@@ -69,7 +64,7 @@ class ShareQrCodeController extends BaseController<ShareQrCodeState> {
   }
 
   save() async {
-    Log.info('保存');
+    // Log.info('保存');
 
     bool req = await requestPermission();
     if (req) {
@@ -81,17 +76,21 @@ class ShareQrCodeController extends BaseController<ShareQrCodeState> {
   // / 动态申请权限，需要区分android和ios，很多时候它两配置权限时各自的名称不同
   // / 此处以保存图片需要的配置为例
   Future<bool> requestPermission() async {
-    late PermissionStatus status;
     // 1、读取系统权限的弹框
-    if (Platform.isIOS) {
-      status = await Permission.photosAddOnly.request();
-    } else {
-      status = await Permission.storage.request();
-      // status = await Permission.manageExternalStorage.request();
+    PermissionStatus storageStatus = await Permission.storage.status;
+    if (storageStatus != PermissionStatus.granted) {
+      if (Platform.isIOS) {
+        storageStatus = await Permission.photosAddOnly.request();
+      } else {
+        storageStatus = await Permission.storage.request();
+        // Log.info('storageStatus: $storageStatus');
+        // storageStatus = await Permission.manageExternalStorage.request();
+      }
     }
+
     // 2、假如你点not allow后，下次点击不会在出现系统权限的弹框（系统权限的弹框只会出现一次），
     // 这时候需要你自己写一个弹框，然后去打开app权限的页面
-    if (status != PermissionStatus.granted) {
+    if (storageStatus != PermissionStatus.granted) {
       showCupertinoDialog(
           context: Get.context!,
           builder: (context) {

--- a/lib/pages/other/share_qr_code/view.dart
+++ b/lib/pages/other/share_qr_code/view.dart
@@ -1,20 +1,13 @@
-import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:get/get.dart';
-import 'package:orginone/config/color.dart';
-import 'package:orginone/config/constant.dart';
 import 'package:orginone/config/index.dart';
-import 'package:orginone/dart/core/chat/message/msgchat.dart';
-import 'package:orginone/dart/core/enum.dart';
 import 'package:orginone/dart/core/getx/base_get_view.dart';
 import 'package:orginone/extension/ex_list.dart';
 import 'package:orginone/extension/ex_widget.dart';
 import 'package:orginone/widget/gy_scaffold.dart';
 import 'package:orginone/widget/image_widget.dart';
 import 'package:orginone/widget/text_widget.dart';
-import 'package:orginone/widget/unified.dart';
-import 'package:orginone/widget/widgets/team_avatar.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 
 import 'logic.dart';
@@ -22,7 +15,7 @@ import 'state.dart';
 
 class ShareQrCodePage
     extends BaseGetView<ShareQrCodeController, ShareQrCodeState> {
-  const ShareQrCodePage({super.key});
+  ShareQrCodePage();
 
   @override
   Widget buildView() {
@@ -35,25 +28,27 @@ class ShareQrCodePage
   Widget buildMainView() {
     return <Widget>[
       buildUserQrInfoView(),
-      buildActions()
-          .paddingTop(GYSpace.page * 1.3)
-          .paddingHorizontal(GYSpace.paragraph)
+      buildActions().paddingHorizontal(GYSpace.paragraph)
     ].toColumn();
   }
 
   Widget buildUserQrInfoView() {
-    return RepaintBoundary(
-      key: controller.globalKey,
-      child: <Widget>[
-        infoView(),
-        buildQRImageView().paddingTop(GYSpace.paragraph),
-        buildTipTextView().paddingTop(GYSpace.card),
-      ]
-          .toColumn()
-          .paddingAll(GYSpace.paragraph)
-          .card(color: GYColors.white)
-          .paddingHorizontal(GYSpace.paragraph)
-          .paddingTop(GYSpace.paragraph * 2),
+    return Container(
+      padding: EdgeInsets.only(
+          top: GYSpace.paragraph * 2,
+          bottom: GYSpace.paragraph,
+          left: GYSpace.paragraph,
+          right: GYSpace.paragraph),
+      child: RepaintBoundary(
+          key: controller.globalKey,
+          child: <Widget>[
+            infoView(),
+            buildQRImageView().paddingTop(GYSpace.paragraph),
+            buildTipTextView().paddingTop(GYSpace.card),
+          ]
+              .toColumn()
+              .paddingAll(GYSpace.paragraph)
+              .card(color: GYColors.white)),
     );
   }
 
@@ -105,7 +100,7 @@ class ShareQrCodePage
   ///提示语
   TextWidget buildTipTextView() {
     return const TextWidget(
-      text: '扫一扫上面的二维码图案，添加我为好友',
+      text: '扫一扫上面的二维码图案，一起分享吧',
       style: TextStyle(
         color: GYColors.gray_99,
         fontSize: 12,


### PR DESCRIPTION
fix：1.部分安卓手机型号，在申请存储相关权限时，无法获取存储权限，跳转到设置里，也无法找到存储相关发现是安卓13版本的问题安卓文档permission_handler的issues里面也有人提出了问题目前(2023-3-6) https://github.com/Baseflow/flutter-permission-handler/issues/995 只能通过降低targetSdkVersion的办法解决，将targetSdkVersion从33变为32

common：2.美化分享和保存的图片